### PR TITLE
refactor: use react-icons on footer and refactor style.css

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,0 +1,53 @@
+import React, { Component } from 'react';
+import { Link } from 'gatsby';
+import { FaTwitter, FaDiscord, FaGithub, FaLinkedin } from 'react-icons/fa';
+
+export default class Footer extends Component {
+    render() {
+        return (
+            <div className="w-full text-center p-4 pin-b mt-8 mb-8">
+                <div>
+                    <img
+                        className="f-32"
+                        src="./banner.png"
+                        alt="#100DaysOfCloud Logo"
+                    />
+                </div>
+
+                <div>
+                    <Link to="#" className="ml-10 text-l">
+                        Our app
+                    </Link>
+                    <Link to="#" className="ml-10 text-l">
+                        About us
+                    </Link>
+                    <Link to="#" className="ml-10 text-l">
+                        Privacy
+                    </Link>
+                    <Link to="#" className="ml-10 text-l">
+                        Contact us
+                    </Link>
+                </div>
+
+                <div className="flex justify-center mt-4">
+                    <Link to="#">
+                        <FaTwitter color="#00ACEE" size="2em" />
+                    </Link>
+                    <Link to="#" className="ml-10 ">
+                        <FaGithub size="2em" />
+                    </Link>
+                    <Link to="#" className="ml-10 ">
+                        <FaLinkedin color=" #0077B5" size="2em" />
+                    </Link>
+                    <Link to="#" className="ml-10 ">
+                        <FaDiscord color="#738ADB" size="2em" />
+                    </Link>
+                </div>
+
+                <div className="mt-4">
+                    Made with ❤️ by the #100DaysOfCloud team
+                </div>
+            </div>
+        );
+    }
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,6 +4,7 @@ import Header from '../components/Header';
 import FeaturedArticle from '../components/FeaturedArticle';
 import ArticleThumbnail from '../components/ArticleThumbnail';
 import NewsCarousel from '../components/NewsCarousel';
+import Footer from '../components/Footer';
 
 import '../styles.css';
 
@@ -11,19 +12,25 @@ export default function Home() {
     return (
         <div className="max-w-8xl m-auto">
             <Header />
-            <div className="grid grid-cols-10 gap-8">
-                <div className="col-span-2">
-                    <ArticleThumbnail provider="medium" />
+
+            <div className="site">
+                <div className="site-content">
+                    <div className="grid grid-cols-10 gap-8">
+                        <div className="col-span-2">
+                            <ArticleThumbnail provider="medium" />
+                        </div>
+                        <div className="col-span-5">
+                            <FeaturedArticle />
+                            <NewsCarousel category="AWS" />
+                            <NewsCarousel category="Azure" />
+                            <NewsCarousel category="Google Cloud" />
+                        </div>
+                        <div className="col-span-3">
+                            <ArticleThumbnail provider="dev" />
+                        </div>
+                    </div>
                 </div>
-                <div className="col-span-5">
-                    <FeaturedArticle />
-                    <NewsCarousel category="AWS" />
-                    <NewsCarousel category="Azure" />
-                    <NewsCarousel category="Google Cloud" />
-                </div>
-                <div className="col-span-3">
-                    <ArticleThumbnail provider="dev" />
-                </div>
+                <Footer />
             </div>
         </div>
     );

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,4 +13,17 @@ html {
   background: #fcfcfc;
 }
 
+.f-32{
+  @apply w-1/3 h-auto block ml-auto mr-auto
+}
+
+.site{
+  @apply flex min-h-screen flex-col
+}
+
+.site-content{
+  @apply flex-grow
+}
+
+
 @tailwind utilities;


### PR DESCRIPTION
I think I got it now ! I did a hard reset (instead of uninstalling all the fontawesome libs and changing the other config files). 
So the changes to merge would be only the Footer component, the changes on index.js to keep the footer on the bottom, and style.css for the footer. I also changed my entries to style.css to keep everything with the tailwind @apply directive. 

